### PR TITLE
Add assert assuming no conditional effects

### DIFF
--- a/planners/powerlifted/src/translator/translate.py
+++ b/planners/powerlifted/src/translator/translate.py
@@ -325,6 +325,7 @@ def print_action_schemas(task, object_index, predicate_index, type_index):
         action.effects.sort(key=lambda x: int(x.literal.negated), reverse=True)
         for eff in action.effects:
             assert isinstance(eff, pddl.Effect)
+            assert isinstance(eff.condition, pddl.conditions.Truth), "Conditional effects are not supported"
             args_list = []
             for x in eff.literal.args:
                 if x in parameter_index:


### PR DESCRIPTION
The parser doesn't throw an error for conditional effects. When these effects are present, the condition is wrongly omitted from the action schema in the intermediate representation.