### PR TITLE
Add build variant without CPLEX

### DIFF
--- a/Apptainer.ragnarok
+++ b/Apptainer.ragnarok
@@ -7,11 +7,12 @@ Stage: build
     planners /planners
 
 %setup
+    #!/bin/bash
     CPLEX_FILE="$IPC_THIRD_PARTY/cplex_studio2211.linux_x86_64.bin"
     if [ -f "$CPLEX_FILE" ]; then
         cp "$CPLEX_FILE" ${APPTAINER_ROOTFS}/cplex.bin
     else
-        if [[ -z "$DISABLE_DECSTAR_ONE" || "$DISABLE_DECSTAR_ONE" -ne 1 ]]; then
+        if [ -z "$DISABLE_DECSTAR_ONE" ]; then
             echo
             echo "ERROR: you need to provide a CPLEX installer to run the IPC version of Ragnarok. \
 Please see the instructions on the IPC 2023 webpage on how to build the planner with CPLEX (https://ipc2023-classical.github.io/). \
@@ -25,6 +26,8 @@ The planner will then build and run without DecStar-1."
     fi
 
 %post
+    #!/bin/bash
+
     ## Install all dependencies.
     apt-get update
     apt-get -y install --no-install-recommends cmake g++ make pypy3 autoconf automake default-jre-headless zlib1g-dev autotools-dev bison ca-certificates flex gdb libboost-dev libboost-program-options-dev
@@ -40,7 +43,7 @@ The planner will then build and run without DecStar-1."
         export DOWNWARD_CPLEX_ROOT=/opt/ibm/ILOG/CPLEX_Studio2211/cplex/
         export DOWNWARD_CPLEX_CONCERT64=/opt/ibm/ILOG/CPLEX_Studio2211/concert/
     else
-        # create empty dirs so copying the folders in stage 2 does not fail
+        # Create empty dirs so copying the folders in stage 2 does not fail.
         mkdir -p /opt/ibm/ILOG/CPLEX_Studio2211/cplex/
         mkdir -p /opt/ibm/ILOG/CPLEX_Studio2211/concert/
     fi
@@ -95,12 +98,16 @@ Stage: run
     /planners/powerlifted/builds/release/translator
 
 %post
+    #!/bin/bash
+
     apt-get update
     apt-get -y install --no-install-recommends pypy3 libboost-dev libboost-program-options-dev
     apt-get clean
     rm -rf /var/lib/apt/lists/*
 
 %runscript
+    #!/bin/bash
+
     DOMAINFILE="$1"
     PROBLEMFILE="$2"
     PLANFILE="$3"

--- a/Apptainer.ragnarok
+++ b/Apptainer.ragnarok
@@ -11,15 +11,17 @@ Stage: build
     if [ -f "$CPLEX_FILE" ]; then
         cp "$CPLEX_FILE" ${APPTAINER_ROOTFS}/cplex.bin
     else
-        echo
-        echo "ERROR: you need to provide a CPLEX installer to run the IPC version of Ragnarok. \
+        if [[ -z "$DISABLE_DECSTAR_ONE" || "$DISABLE_DECSTAR_ONE" -ne 1 ]]; then
+            echo
+            echo "ERROR: you need to provide a CPLEX installer to run the IPC version of Ragnarok. \
+Please see the instructions on the IPC 2023 webpage on how to build the planner with CPLEX (https://ipc2023-classical.github.io/). \
 Without CPLEX, the decoupled-search component (DecStar-1) is not working. \
-If you want to run Ragnarok without that component, you can remove the \"exit 1\" \
-command in line 22 of the Apptainer.ragnarok file. The planner will then build and run \
-without DecStar-1. If you want to use a different CPLEX version, you can change the file \
-name in line 10. Note, though, that not all versions will work."
-        echo
-        exit 1
+If you want to run Ragnarok without that component, you can define an environment variable as follows: \
+export DISABLE_DECSTAR_ONE=1; \
+The planner will then build and run without DecStar-1."
+            echo
+            exit 1
+        fi
     fi
 
 %post

--- a/Apptainer.ragnarok
+++ b/Apptainer.ragnarok
@@ -5,8 +5,22 @@ Stage: build
 
 %files
     planners /planners
-    $IPC_THIRD_PARTY/cplex_studio2211.linux_x86_64.bin cplex.bin
-    Osi-0.108.6.tgz
+
+%setup
+    CPLEX_FILE="$IPC_THIRD_PARTY/cplex_studio2211.linux_x86_64.bin"
+    if [ -f "$CPLEX_FILE" ]; then
+        cp "$CPLEX_FILE" ${APPTAINER_ROOTFS}/cplex.bin
+    else
+        echo
+        echo "ERROR: you need to provide a CPLEX installer to run the IPC version of Ragnarok. \
+Without CPLEX, the decoupled-search component (DecStar-1) is not working. \
+If you want to run Ragnarok without that component, you can remove the \"exit 1\" \
+command in line 22 of the Apptainer.ragnarok file. The planner will then build and run \
+without DecStar-1. If you want to use a different CPLEX version, you can change the file \
+name in line 10. Note, though, that not all versions will work."
+        echo
+        exit 1
+    fi
 
 %post
     ## Install all dependencies.
@@ -16,31 +30,18 @@ Stage: build
     ## Clear local build directories.
     rm -rf /planners/*/builds
 
-    ## Build CPLEX
-    chmod +x ./cplex.bin
-    ./cplex.bin -DLICENSE_ACCEPTED=TRUE -i silent
+    if [ -f "cplex.bin" ]; then
+        ## Build CPLEX
+        chmod +x ./cplex.bin
+        ./cplex.bin -DLICENSE_ACCEPTED=TRUE -i silent
 
-    export DOWNWARD_CPLEX_ROOT=/opt/ibm/ILOG/CPLEX_Studio2211/cplex/
-    export DOWNWARD_CPLEX_CONCERT64=/opt/ibm/ILOG/CPLEX_Studio2211/concert/
-
-    ##Build OSI
-    tar xvzf Osi-0.108.6.tgz
-    cd Osi-0.108.6
-    export DOWNWARD_COIN_ROOT=/opt/coin/
-
-    ./configure CC="gcc"  CFLAGS="-pthread -Wno-long-long" \
-            CXX="g++" CXXFLAGS="-pthread -Wno-long-long" \
-            LDFLAGS="-L$DOWNWARD_CPLEX_ROOT/lib/x86-64_linux/static_pic" \
-            --without-lapack --enable-static=yes \
-            --prefix="$DOWNWARD_COIN_ROOT" \
-            --disable-bzlib  \
-            --with-cplex-incdir=$DOWNWARD_CPLEX_ROOT/include/ilcplex \
-            --with-cplex-lib="-lcplex -lm -ldl"
-
-    make
-    make install
-
-    cd ..
+        export DOWNWARD_CPLEX_ROOT=/opt/ibm/ILOG/CPLEX_Studio2211/cplex/
+        export DOWNWARD_CPLEX_CONCERT64=/opt/ibm/ILOG/CPLEX_Studio2211/concert/
+    else
+        # create empty dirs so copying the folders in stage 2 does not fail
+        mkdir -p /opt/ibm/ILOG/CPLEX_Studio2211/cplex/
+        mkdir -p /opt/ibm/ILOG/CPLEX_Studio2211/concert/
+    fi
 
     ## Build bliss
     cd planners/decstar/third-party/bliss-0.73
@@ -74,7 +75,6 @@ Stage: run
 %files from build
     /opt/ibm/ILOG/CPLEX_Studio2211/cplex/
     /opt/ibm/ILOG/CPLEX_Studio2211/concert/
-    /opt/coin/
 
     /planners/decstar/builds/release64/bin/downward /planners/decstar/builds/release/bin/downward
     /planners/decstar/third-party/bliss-0.73/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-The third party Software OSI shipped within this repository (Osi-0.108.6.tgz) is licensed under the Eclipse Public License version 2.0 (EPL 2.0).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+The following description is based on the IPC'23 competition webpage (https://ipc2023-classical.github.io/):
+
+Using IPC 2023 planners
+
+All participating planners can be used as Apptainer images. To build such an image, install Apptainer and clone the corresponding planner repository. You can find links to them in the list of participants. Code repositories contain two branches: ipc2023-classical contains exactly the code version that ran in the IPC, while latest can contain additional bug fixes published after the competition. We recommend using latest for all experiments. Some code repositories contain multiple Apptainer files for different planners that share a code base. Use Apptainer to build the planner from one of those recipes like this:
+
+Some planners (including Ragnarok) require CPLEX to run. To use them, you have to acquire a CPLEX license (IBM offers free academic licenses) and download the installer file cplex_studio2211.linux_x86_64.bin. Place it into a directory and use the environment variable IPC_THIRD_PARTY to identify it.
+
+```
+export IPC_THIRD_PARTY=/path/to/some/directory
+cp cplex_studio2211.linux_x86_64.bin $IPC_THIRD_PARTY
+git clone https://github.com/ipc2023-classical/planner17.git
+cd planner17
+sudo apptainer build ragnarok.sif Apptainer.ragnarok
+```
+
+You need to provide a CPLEX installer to run the IPC version of Ragnarok. Without CPLEX, the decoupled-search component (DecStar-1) is not working.
+
+If you want to run Ragnarok without that component, you can define an environment variable as follows:
+
+```
+export DISABLE_DECSTAR_ONE=1
+```
+
+The planner will then build and run without DecStar-1. Note that this only works in the branch latest.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,34 @@
-The following description is based on the IPC'23 competition webpage (https://ipc2023-classical.github.io/):
+# Ragnarok
 
-Using IPC 2023 planners
+Ragnarok is a sequential portfolio planner that uses several classical planners
+developed by members of the Representation, Learning and Planning Lab at
+Linköping University in Sweden. Much like the Norse saga Ragnarök, from whom our
+portfolio planner takes its name, our component planners battled each other in a
+training phase, from which we obtained the time slices for each component to
+create a portfolio that combines their individual strengths. This portfolio
+participated in and won the Optimal Track of the International Planning
+Competition 2023.
 
-All participating planners can be used as Apptainer images. To build such an image, install Apptainer and clone the corresponding planner repository. You can find links to them in the list of participants. Code repositories contain two branches: ipc2023-classical contains exactly the code version that ran in the IPC, while latest can contain additional bug fixes published after the competition. We recommend using latest for all experiments. Some code repositories contain multiple Apptainer files for different planners that share a code base. Use Apptainer to build the planner from one of those recipes like this:
+The following instructions are based on the [IPC 2023 competition webpage](https://ipc2023-classical.github.io/).
 
-Some planners (including Ragnarok) require CPLEX to run. To use them, you have to acquire a CPLEX license (IBM offers free academic licenses) and download the installer file cplex_studio2211.linux_x86_64.bin. Place it into a directory and use the environment variable IPC_THIRD_PARTY to identify it.
+## Using IPC 2023 planners
 
-```
-export IPC_THIRD_PARTY=/path/to/some/directory
-cp cplex_studio2211.linux_x86_64.bin $IPC_THIRD_PARTY
-git clone https://github.com/ipc2023-classical/planner17.git
-cd planner17
-sudo apptainer build ragnarok.sif Apptainer.ragnarok
-```
+All participating planners can be used as Apptainer images. To build such an image, install Apptainer and clone the corresponding planner repository. You can find links to them in the list of participants. Code repositories contain two branches: "ipc2023-classical" contains exactly the code version that ran in the IPC, while "latest" can contain additional bug fixes published after the competition. **We recommend using "latest" for all experiments**. Some code repositories contain multiple Apptainer files for different planners that share a code base. Use Apptainer to build the planner from one of those recipes like this:
 
-You need to provide a CPLEX installer to run the IPC version of Ragnarok. Without CPLEX, the decoupled-search component (DecStar-1) is not working.
+Some planners (including Ragnarok) require CPLEX to run. To use them, you have to acquire a CPLEX license (IBM offers free academic licenses) and download the installer file `cplex_studio2211.linux_x86_64.bin`. Place it into a directory and use the environment variable `IPC_THIRD_PARTY` to identify it.
+
+    export IPC_THIRD_PARTY=/path/to/some/directory
+    cp cplex_studio2211.linux_x86_64.bin $IPC_THIRD_PARTY
+    git clone https://github.com/ipc2023-classical/planner17.git
+    cd planner17
+    git switch latest
+    apptainer build ragnarok.sif Apptainer.ragnarok
+    ./ragnarok.sif path/to/domain.pddl path/to/problem.pddl sas_plan
+
+You need to provide a CPLEX installer to run the IPC version of Ragnarok. Without CPLEX, the decoupled-search component (DecStar-1) does not work.
 
 If you want to run Ragnarok without that component, you can define an environment variable as follows:
 
-```
-export DISABLE_DECSTAR_ONE=1
-```
+    export DISABLE_DECSTAR_ONE=1
 
-The planner will then build and run without DecStar-1. Note that this only works in the branch latest.
+The planner will then build and run without DecStar-1. Note that this only works on the "latest" branch.

--- a/planners/powerlifted/src/translator/translate.py
+++ b/planners/powerlifted/src/translator/translate.py
@@ -325,6 +325,7 @@ def print_action_schemas(task, object_index, predicate_index, type_index):
         action.effects.sort(key=lambda x: int(x.literal.negated), reverse=True)
         for eff in action.effects:
             assert isinstance(eff, pddl.Effect)
+            assert isinstance(eff.condition, pddl.conditions.Truth), "Conditional effects are not supported"
             args_list = []
             for x in eff.literal.args:
                 if x in parameter_index:

--- a/planners/scorpion/src/search/cegar/cegar.cc
+++ b/planners/scorpion/src/search/cegar/cegar.cc
@@ -109,9 +109,18 @@ void CEGAR::separate_facts_unreachable_before_goal() const {
       Split off the goal fact from the initial state. Then the new initial
       state is the only non-goal state and no goal state will have to be split
       later.
+
+      For all states s in which the landmark might have been achieved we need
+      h(s)=0. If the limits don't allow splitting off all facts unreachable
+      before the goal to achieve this, we instead preserve h(s)=0 for *all*
+      states s and cannot split off the goal fact from the abstract initial
+      state.
     */
-    abstraction->refine(
-        abstraction->get_initial_state(), goal.get_variable().get_id(), {goal.get_value()});
+    assert(abstraction->get_initial_state().includes(task_proxy.get_initial_state()));
+    assert(reachable_facts.count(goal));
+    if (may_keep_refining()) {
+        abstraction->refine(abstraction->get_initial_state(), goal.get_variable().get_id(), {goal.get_value()});
+    }
 }
 
 bool CEGAR::may_keep_refining() const {


### PR DESCRIPTION
This adds a build variant to the Apptainer recipe that allows to easily remove the CPLEX requirement of the original planner. This is done by defining an environment variable called DISABLE_DECSTAR_ONE. If defined, the planner builds without CPLEX installer and runs without DecStar-1 component. This is described in the new README file.
Since the CPLEX integration does not rely on OSI, we removed it entirely.